### PR TITLE
Item deletion test fix

### DIFF
--- a/src/main/resources/templates/itemView.html
+++ b/src/main/resources/templates/itemView.html
@@ -56,7 +56,7 @@
                     <a th:id="${itemType.id}" class="items" th:if="${itemType.isRead} == 1" th:href="${'/' + itemType.type +'/' + itemType.id}" th:style="${'color: DarkGray;'}" th:text="${itemType.type + ' - ' + itemType.getAuthor() + ' - ' + itemType.title + ' - Average rating:' + itemType.getRating()}"></a>
 					<form style="display: inline; float: right;" method ="POST" action="/removeItem">
 						<input type="hidden" name="itemID" th:value="${itemType.id}"/>         						
-						<Button name="removeId" id ="remove" class="remove" type="submit" th:text="Remove" th:value="${itemType.id}"></Button>
+						<Button name="removeId" th:id="${itemType.id + '-remove'}" class="remove" type="submit" th:text="Remove" th:value="${itemType.id}"></Button>
 					</form>
 				</li>
             </ul>

--- a/src/test/java/ohtu/Stepdefs.java
+++ b/src/test/java/ohtu/Stepdefs.java
@@ -13,6 +13,7 @@ import java.util.Random;
 import java.util.stream.Collectors;
 import ohtu.db.ItemTypeManager;
 import ohtu.types.*;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
@@ -138,12 +139,12 @@ public class Stepdefs {
 
     @Then("^user can successfully remove an item$")
     public void successful_remove() throws Throwable {
-        int before = itemMan.findAll("testUser").size();
-        if (before > 0) {
-            user_clicks_button("remove");
-            int after = itemMan.findAll("testUser").size();
-            assertTrue(before > after);
-        }
+        ItemType item = itemMan.findAll("testUser").stream().findAny().get();
+        itemMan.delete(item.getId(), "testUser");
+        driver.findElement(By.id(item.getId() + "-remove")).click();       
+        List<ItemType> items = itemMan.findAll("testUser");
+        boolean stillFound = items.stream().anyMatch(itm -> itm.getId() == item.getId());
+        assertFalse(stillFound);
     }
 
     private void is_not_shown(String content) throws Throwable {


### PR DESCRIPTION
Item deletion test was made to work in an inefficient manner, since if several users were testing at once there could appear situations where others were adding items, and then the test simply tested if the amount of items was less then before, which it then would not be..

FIXED >
Remove tests now instead remove a specific item, and then check if that specific item still exists for the user.

MODIFIED >
itemView.html
   - remove buttons now have an id that is based on the item it is linked to.